### PR TITLE
Optimize ml-dsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Test with [ckb-debugger 1.1.0](https://github.com/nervosnetwork/ckb-standalone-d
 | schnorr     |  3.5M Cycles  | 80K Bytes  | N/A      |
 | k256        |  3.8M Cycles  | 97K Bytes  | Recovery |
 | sp1 verifier|  63.2M Cycles | 246K Bytes | Plonk    |
-| ml-dsa-44   |  4.6M Cycles | 104K Bytes  | N/A      |
-| ml-dsa-65   |  7.4M cycles | 104K Bytes  | N/A      |
-| ml-dsa-87   | 12.3M Cycles | 104K Bytes  | N/A      |
+| ml-dsa-44   |  3.2M Cycles | 119K Bytes  | N/A      |
+| ml-dsa-65   |  4.8M cycles | 119K Bytes  | N/A      |
+| ml-dsa-87   |  7.5M Cycles | 119K Bytes  | N/A      |

--- a/contracts/ml-dsa-test/Cargo.lock
+++ b/contracts/ml-dsa-test/Cargo.lock
@@ -41,9 +41,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ckb-opt-fips202"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7863e6e78ae89cd0df06aabf80e5554c296d20d5978e10a2ba61bda01c0a366e"
+checksum = "694fc41e024cf511e602305ec0191d46a72e6c67a3cab3efb5f8713f3569b24b"
 dependencies = [
  "cc",
  "clang-finder",
@@ -169,7 +169,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 [[package]]
 name = "ml-dsa"
 version = "0.1.0-rc.8"
-source = "git+https://github.com/XuJiandong/signatures.git?rev=591a7bb#591a7bb290790dea6ced9b0b98a52c14a5c33b90"
+source = "git+https://github.com/XuJiandong/signatures.git?rev=6d6f2b6#6d6f2b6a66cc611b88a9ec473b62a2a95eb4919c"
 dependencies = [
  "ckb-opt-fips202",
  "ctutils",

--- a/contracts/ml-dsa-test/Cargo.lock
+++ b/contracts/ml-dsa-test/Cargo.lock
@@ -40,6 +40,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ckb-opt-fips202"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7863e6e78ae89cd0df06aabf80e5554c296d20d5978e10a2ba61bda01c0a366e"
+dependencies = [
+ "cc",
+ "clang-finder",
+]
+
+[[package]]
 name = "ckb-std"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +60,12 @@ dependencies = [
  "gcd",
  "int-enum",
 ]
+
+[[package]]
+name = "clang-finder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366a7b5c4c05a3aefd92ed5412ea1d54ed5afbf550c68c268b16d3be6a108cf9"
 
 [[package]]
 name = "cmov"
@@ -153,8 +169,9 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 [[package]]
 name = "ml-dsa"
 version = "0.1.0-rc.8"
-source = "git+https://github.com/RustCrypto/signatures?rev=66473ec#66473ecba8634591ccd58efbca0c4c9c7489c8a6"
+source = "git+https://github.com/XuJiandong/signatures.git?rev=591a7bb#591a7bb290790dea6ced9b0b98a52c14a5c33b90"
 dependencies = [
+ "ckb-opt-fips202",
  "ctutils",
  "hybrid-array",
  "module-lattice",

--- a/contracts/ml-dsa-test/Cargo.lock
+++ b/contracts/ml-dsa-test/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "ee741d62dcaf41ca303576ef890989ccb01d5dd77f8ce1a6d6c7846ab5d09efb"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clang-finder"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366a7b5c4c05a3aefd92ed5412ea1d54ed5afbf550c68c268b16d3be6a108cf9"
+checksum = "8f694582dc53473115d9263891e1dae5fe6861b2fc1796fc853e2b113aa6d5c4"
 
 [[package]]
 name = "cmov"

--- a/contracts/ml-dsa-test/Cargo.toml
+++ b/contracts/ml-dsa-test/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 
 [dependencies]
 ckb-std = { version = "1.0.0", default-features = false, features = ["allocator", "dummy-atomic"] }
-# ml-dsa = { git = "https://github.com/RustCrypto/signatures", default-features = false, rev = "66473ec" }
-ml-dsa = { git = "https://github.com/XuJiandong/signatures.git", default-features = false, rev = "591a7bb" }
+ml-dsa = { git = "https://github.com/XuJiandong/signatures.git", default-features = false, rev = "6d6f2b6" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [profile.release]

--- a/contracts/ml-dsa-test/Cargo.toml
+++ b/contracts/ml-dsa-test/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 ckb-std = { version = "1.0.0", default-features = false, features = ["allocator", "dummy-atomic"] }
-ml-dsa = { git = "https://github.com/RustCrypto/signatures", default-features = false, rev = "66473ec" }
+# ml-dsa = { git = "https://github.com/RustCrypto/signatures", default-features = false, rev = "66473ec" }
+ml-dsa = { git = "https://github.com/XuJiandong/signatures.git", default-features = false, rev = "591a7bb" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [profile.release]

--- a/contracts/ml-dsa-test/src/entry.rs
+++ b/contracts/ml-dsa-test/src/entry.rs
@@ -2,8 +2,8 @@ use alloc::vec::Vec;
 use core::result::Result;
 
 use crate::error::Error;
-use ckb_std::syscalls::{current_cycles, debug};
 use alloc::format;
+use ckb_std::syscalls::{current_cycles, debug};
 use ml_dsa::{EncodedVerifyingKey, MlDsa44, MlDsa65, MlDsa87, Signature, VerifyingKey};
 
 pub fn main() -> Result<(), Error> {
@@ -25,9 +25,7 @@ pub fn main() -> Result<(), Error> {
         }
         b"MlDsa65" => {
             let enc_vk = EncodedVerifyingKey::<MlDsa65>::try_from(vk_bytes.as_slice()).unwrap();
-            let cycles = current_cycles();
             let vk = VerifyingKey::<MlDsa65>::decode(&enc_vk);
-            debug(format!("decode costs {} K cycles", (current_cycles() - cycles)/1024));
             let sig = Signature::<MlDsa65>::try_from(sig_bytes.as_slice()).unwrap();
             assert!(vk.verify_with_context(&msg_bytes, &ctx, &sig));
         }

--- a/contracts/ml-dsa-test/src/entry.rs
+++ b/contracts/ml-dsa-test/src/entry.rs
@@ -25,7 +25,9 @@ pub fn main() -> Result<(), Error> {
         }
         b"MlDsa65" => {
             let enc_vk = EncodedVerifyingKey::<MlDsa65>::try_from(vk_bytes.as_slice()).unwrap();
+            let cycles = current_cycles();
             let vk = VerifyingKey::<MlDsa65>::decode(&enc_vk);
+            debug(format!("decode costs {} K cycles", (current_cycles() - cycles)/1024));
             let sig = Signature::<MlDsa65>::try_from(sig_bytes.as_slice()).unwrap();
             assert!(vk.verify_with_context(&msg_bytes, &ctx, &sig));
         }


### PR DESCRIPTION
The main changes include:
1. Use an optimized [SHAKE128 implementation](https://github.com/nervosnetwork/ckb-vm-contrib/tree/main/opt-lib/fips202)
2. Optimize the matrix-filling strategy

The changes are small and easy to review. Benchmark results:

| Variant   | Before  | After   |
|-----------|---------|---------|
| ml-dsa-44 | 4.6M    | 3.2M    |
| ml-dsa-65 | 7.4M    | 4.8M    |
| ml-dsa-87 | 12.3M   | 7.5M    |

Approximately 60–70% of the original cycle count.